### PR TITLE
v18.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 COMMON_OVERLAYS = tkl-webcp
-PHP_EXTRA_PINS=libpcre2-8-0
 PHP_VERSION=8.1
 include $(FAB_PATH)/common/mk/turnkey/lamp.mk
 include $(FAB_PATH)/common/mk/turnkey/composer.mk

--- a/changelog
+++ b/changelog
@@ -1,3 +1,14 @@
+turnkey-cakephp-18.0 (1) turnkey; urgency=low
+
+  * Latest upstream versiion of CakePHP - v5.0.4.
+
+  * Updated all relevant Debian packages to Bookworm/12 versions
+
+  * Note: Please refer to turnkey-core's 18.0 changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Anton Pyrogovskyi <anton@turnkeylinux.org>  Sat, 13 Jan 2024 16:08:47 +0100
+
 turnkey-cakephp-17.1 (1) turnkey; urgency=low
 
   * Updated all Debian packages to latest.

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -5,11 +5,8 @@ dl() {
     cd $2; curl -L -f -O $PROXY $1; cd -
 }
 
-GH_API=https://api.github.com/repos/cakephp/cakephp/releases       
-VERSION=$(curl -s $GH_API |grep -oP '"tag_name": "\K(.*)(?=")' | grep -iv beta \
-    | grep -iv rc | sort --version-sort | tail -1)
+VERSION=$(gh_releases cakephp/cakephp | tail -1)
 FILENAME="cakephp-$(echo $VERSION | sed 's|\.|-|g').zip"
-
 URL="https://github.com/cakephp/cakephp/releases/download/$VERSION/$FILENAME"
 
 dl $URL /usr/local/src

--- a/conf.d/main
+++ b/conf.d/main
@@ -15,7 +15,7 @@ chown -R root:root $WEBROOT
 chown -R www-data:www-data $WEBROOT/tmp
 
 # put landing page images in place
-for img in adminer.png shell.png webmin.png; do
+for img in adminer.png webmin.png; do
     mv /var/www/images/$img  $WEBROOT/webroot/img/
 done
 rm -r /var/www/{css,images,js}

--- a/conf.d/main
+++ b/conf.d/main
@@ -55,6 +55,9 @@ sed -i "/DebugKit/,/<hr>/ {
             <?php include 'turnkey-shim.php' ?>
     };" /var/www/cakephp/templates/Pages/home.php
 
+# turn on assertions to avoid cakephp warning
+sed -i '/^zend\.assertions/ s|-1$|1|' /etc/php/8.?/{cli,apache2}/php.ini
+
 chown www-data:www-data $CONF
 chmod 640 $CONF
 

--- a/overlay/var/www/cakephp/templates/Pages/turnkey-shim.php
+++ b/overlay/var/www/cakephp/templates/Pages/turnkey-shim.php
@@ -17,9 +17,6 @@
     <h4>Also comes with the usual TurnKey shipped tools:</h4>
 <div class="row">
     <div class="column">
-        <a href="https://<?php print $_SERVER['HTTP_HOST']; ?>:12320">Web Shell</a>
-    </div>
-    <div class="column">
         &nbsp;
         <a href="https://<?php print $_SERVER['HTTP_HOST']; ?>:12321">Webmin</a>
     </div>
@@ -29,9 +26,6 @@
     </div>
 </div>
 <div class="row">
-    <div class="column">
-        <a href="https://<?php print $_SERVER['HTTP_HOST']; ?>:12320"><img src="img/shell.png" alt="Webshell"></a>
-    </div>
     <div class="column">
         <a href="https://<?php print $_SERVER['HTTP_HOST']; ?>:12321"><img src="img/webmin.png" alt="Webmin"></a>
     </div>


### PR DESCRIPTION
- remove webshell reference from main page
- remove obsolete PHP_EXTRA_PINS value
- use gh_releases to get latest release
- turn on zend.assertions
- update changelog
